### PR TITLE
Update Andrew Hankinson info

### DIFF
--- a/participants.html
+++ b/participants.html
@@ -62,7 +62,7 @@
       <p>Marianne Gillion<br>KU Leuven<br></p>
       <p>Richard Haefer<br>Arizona State University<br></p>
       <p>Barbara Haggh-Huglo<br>University of Maryland<br></p>
-      <p>Andrew Hankinson<br>RISM Switzerland<br></p>
+      <p>Andrew Hankinson<br>RISM Digital Center<br></p>
       <p>Jane Hardie<br>University of Sydney<br></p>
       <p>Thomas Forrest Kelly<br>Harvard University<br></p>
       <p>Sarah Ann Long<br>Michigan State University<br></p>


### PR DESCRIPTION
I have updated my affiliation from RISM Switzerland to the RISM Digital Center.