### PR TITLE
Split Participants page into People and Partners pages

### DIFF
--- a/hildegard.html
+++ b/hildegard.html
@@ -14,6 +14,7 @@
   <link href="css/dact.webflow.css" rel="stylesheet" type="text/css">
   <!-- [if lt IE 9]><script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js" type="text/javascript"></script><![endif] -->
   <script type="text/javascript">!function(o,c){var n=c.documentElement,t=" w-mod-";n.className+=t+"js",("ontouchstart"in o||o.DocumentTouch&&c instanceof DocumentTouch)&&(n.className+=t+"touch")}(window,document);</script>
+  <script src="js/dropdown.js" type="text/javascript"></script>
   <link href="images/favicon.png" rel="shortcut icon" type="image/x-icon">
   <link href="images/webclip.png" rel="apple-touch-icon">
 </head>
@@ -23,26 +24,33 @@
       <div class="w-nav-button">
         <div class="w-icon-nav-menu"></div>
       </div>
-	<nav role="navigation" class="w-nav-menu">
-		<a href="index.html" class="nav-link w-nav-link">Home</a>
-		<div class="dropdown nav-link w-nav-link">
-		  <button class="dropbtn" onclick="toggleDropdown()">
-			Activities ▼
-		  </button>
-		  <div class="dropdown-content" id="activitiesDropdown">
-		    <a href="presentations.html" class="nav-link w-nav-link">Presentations</a>
-			<a href="publications.html" class="nav-link w-nav-link">Publications</a>
-			<a href="workshops.html" class="nav-link w-nav-link">Workshops</a>
-		  </div>
-	  	</div>
-		<script src="js/dropdown.js" type="text/javascript"></script>
-		<a href="projects.html" class="nav-link w-nav-link">Projects</a>
-		<a href="participants.html" class="nav-link w-nav-link">Participants</a>
-		<a href="hildegard.html" class="nav-link w-nav-link">Hildegard Music Research Guide</a>
-		<a href="mailto:debra.lacoste@dal.ca?subject=DACT%20website%20" class="w-nav-link">Contact us</a>
-	</nav>
-      <a href="index.html" class="w-inline-block"><img src="images/DACT-logo-withoutbg.png" width="200" srcset="images/DACT-logo-withoutbg-p-500.png 500w, images/DACT-logo-withoutbg-p-800.png 800w, images/DACT-logo-withoutbg.png 837w" sizes="200px" alt=""></a></div>
-   </div>
+    	<nav role="navigation" class="w-nav-menu">
+      	<a href="index.html" class="nav-link w-nav-link">Home</a>
+      	<div class="dropdown nav-link w-nav-link">
+      	  <button class="dropbtn activities-dropdown-button">
+            Activities ▼
+      	  </button>
+      	  <div class="dropdown-content" id="activitiesDropdown">
+      	    <a href="presentations.html" class="nav-link w-nav-link">Presentations</a>
+      		<a href="publications.html" class="nav-link w-nav-link">Publications</a>
+      		<a href="workshops.html" class="nav-link w-nav-link">Workshops</a>
+      	  </div>
+        	</div>
+      	<a href="projects.html" class="nav-link w-nav-link">Projects</a>
+      	<div class="dropdown nav-link w-nav-link">
+      	  <button class="dropbtn participants-dropdown-button">
+            Participants ▼
+      	  </button>
+      	  <div class="dropdown-content" id="participantsDropdown">
+      	    <a href="partners.html" class="nav-link w-nav-link">Partners</a>
+      		<a href="people.html" class="nav-link w-nav-link">People</a>
+      	  </div>
+        	</div>
+      	<a href="hildegard.html" class="nav-link w-nav-link">Hildegard Music Research Guide</a>
+      	<a href="mailto:debra.lacoste@dal.ca?subject=DACT%20website%20" class="w-nav-link">Contact us</a>
+    	</nav>
+    </div>
+  </div>
   <div class="section-2">
     <div class="div-block-3"><img src="images/alina-grubnyak-ZiQkhI7417A-unsplash.jpg" srcset="images/alina-grubnyak-ZiQkhI7417A-unsplash-p-1080.jpeg 1080w, images/alina-grubnyak-ZiQkhI7417A-unsplash-p-1600.jpeg 1600w, images/alina-grubnyak-ZiQkhI7417A-unsplash-p-2000.jpeg 2000w, images/alina-grubnyak-ZiQkhI7417A-unsplash-p-2600.jpeg 2600w, images/alina-grubnyak-ZiQkhI7417A-unsplash-p-3200.jpeg 3200w, images/alina-grubnyak-ZiQkhI7417A-unsplash.jpg 3456w" sizes="(max-width: 3456px) 100vw, 3456px" alt="" class="image-3"></div>
     <div>

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
   <link href="css/dact.webflow.css" rel="stylesheet" type="text/css">
   <!-- [if lt IE 9]><script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js" type="text/javascript"></script><![endif] -->
   <script type="text/javascript">!function(o,c){var n=c.documentElement,t=" w-mod-";n.className+=t+"js",("ontouchstart"in o||o.DocumentTouch&&c instanceof DocumentTouch)&&(n.className+=t+"touch")}(window,document);</script>
+  <script src="js/dropdown.js" type="text/javascript"></script>
   <link href="images/favicon.png" rel="shortcut icon" type="image/x-icon">
   <link href="images/webclip.png" rel="apple-touch-icon">
 </head>
@@ -23,24 +24,31 @@
       <div class="w-nav-button">
         <div class="w-icon-nav-menu"></div>
       </div>
-	<nav role="navigation" class="w-nav-menu">
-		<a href="index.html" class="nav-link w-nav-link">Home</a>
-		<div class="dropdown nav-link w-nav-link">
-		  <button class="dropbtn" onclick="toggleDropdown()">
-			Activities ▼
-		  </button>
-		  <div class="dropdown-content" id="activitiesDropdown">
-		    <a href="presentations.html" class="nav-link w-nav-link">Presentations</a>
-			<a href="publications.html" class="nav-link w-nav-link">Publications</a>
-			<a href="workshops.html" class="nav-link w-nav-link">Workshops</a>
-		  </div>
-	  	</div>
-		<script src="js/dropdown.js" type="text/javascript"></script>
-		<a href="projects.html" class="nav-link w-nav-link">Projects</a>
-		<a href="participants.html" class="nav-link w-nav-link">Participants</a>
-		<a href="hildegard.html" class="nav-link w-nav-link">Hildegard Music Research Guide</a>
-		<a href="mailto:debra.lacoste@dal.ca?subject=DACT%20website%20" class="w-nav-link">Contact us</a>
-	</nav>
+    	<nav role="navigation" class="w-nav-menu">
+      	<a href="index.html" class="nav-link w-nav-link">Home</a>
+      	<div class="dropdown nav-link w-nav-link">
+      	  <button class="dropbtn activities-dropdown-button">
+            Activities ▼
+      	  </button>
+      	  <div class="dropdown-content" id="activitiesDropdown">
+      	    <a href="presentations.html" class="nav-link w-nav-link">Presentations</a>
+      		<a href="publications.html" class="nav-link w-nav-link">Publications</a>
+      		<a href="workshops.html" class="nav-link w-nav-link">Workshops</a>
+      	  </div>
+        	</div>
+      	<a href="projects.html" class="nav-link w-nav-link">Projects</a>
+      	<div class="dropdown nav-link w-nav-link">
+      	  <button class="dropbtn participants-dropdown-button">
+            Participants ▼
+      	  </button>
+      	  <div class="dropdown-content" id="participantsDropdown">
+      	    <a href="partners.html" class="nav-link w-nav-link">Partners</a>
+      		<a href="people.html" class="nav-link w-nav-link">People</a>
+      	  </div>
+        	</div>
+      	<a href="hildegard.html" class="nav-link w-nav-link">Hildegard Music Research Guide</a>
+      	<a href="mailto:debra.lacoste@dal.ca?subject=DACT%20website%20" class="w-nav-link">Contact us</a>
+    	</nav>
     </div>
   </div>
   <div class="section-2">

--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -1,12 +1,36 @@
-function toggleDropdown() {
-  document.getElementById("activitiesDropdown").classList.toggle("show");
-}
+window.onclick = function(event) {
+  var activitiesDropdown = document.getElementById("activitiesDropdown");
+  var participantsDropdown = document.getElementById("participantsDropdown");
 
-window.onclick = function(e) {
-  if (!e.target.matches('.dropbtn')) {
-  var myDropdown = document.getElementById("activitiesDropdown");
-    if (myDropdown.classList.contains('show')) {
-      myDropdown.classList.remove('show');
+  if (event.target.matches('.activities-dropdown-button')) {
+    // someone has clicked on activitiesDropdown
+    if (activitiesDropdown.classList.contains('show')) {
+      // activitiesDropdown is currently activated, so deactivate it.
+      activitiesDropdown.classList.remove('show');
+    } else {
+      // activitiesDropdown is currently not activated, so activate it.
+      activitiesDropdown.classList.add('show');
+    }
+  } else {
+    // the click was somewhere other than activitiesDropdown, so deactivate it.
+    if (activitiesDropdown.classList.contains('show')) {
+      activitiesDropdown.classList.remove('show');
+    }
+  }
+
+  if (event.target.matches('.participants-dropdown-button')) {
+    // someone has clicked on participantsDropdown
+    if (participantsDropdown.classList.contains('show')) {
+      // participantsDropdown is currently activated, so deactivate it.
+      participantsDropdown.classList.remove('show');
+    } else {
+      // participantsDropdown is currently not activated, so activate it.
+      participantsDropdown.classList.add('show');
+    }
+  } else {
+    // the click was somewhere other than participantsDropdown, so deactivate it.
+    if (participantsDropdown.classList.contains('show')) {
+      participantsDropdown.classList.remove('show');
     }
   }
 }

--- a/participants.html
+++ b/participants.html
@@ -14,33 +14,42 @@
   <link href="css/dact.webflow.css" rel="stylesheet" type="text/css">
   <!-- [if lt IE 9]><script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js" type="text/javascript"></script><![endif] -->
   <script type="text/javascript">!function(o,c){var n=c.documentElement,t=" w-mod-";n.className+=t+"js",("ontouchstart"in o||o.DocumentTouch&&c instanceof DocumentTouch)&&(n.className+=t+"touch")}(window,document);</script>
+  <script src="js/dropdown.js" type="text/javascript"></script>
   <link href="images/favicon.png" rel="shortcut icon" type="image/x-icon">
   <link href="images/webclip.png" rel="apple-touch-icon">
 </head>
 <body>
   <div data-collapse="medium" data-animation="default" data-duration="400" class="w-nav">
     <div class="w-container">
-	<nav role="navigation" class="w-nav-menu">
-		<a href="index.html" class="nav-link w-nav-link">Home</a>
-		<div class="dropdown nav-link w-nav-link">
-		  <button class="dropbtn" onclick="toggleDropdown()">
-			Activities ▼
-		  </button>
-		  <div class="dropdown-content" id="activitiesDropdown">
-		    <a href="presentations.html" class="nav-link w-nav-link">Presentations</a>
-			<a href="publications.html" class="nav-link w-nav-link">Publications</a>
-			<a href="workshops.html" class="nav-link w-nav-link">Workshops</a>
-		  </div>
-	  	</div>
-		<script src="js/dropdown.js" type="text/javascript"></script>
-		<a href="projects.html" class="nav-link w-nav-link">Projects</a>
-		<a href="participants.html" class="nav-link w-nav-link">Participants</a>
-		<a href="hildegard.html" class="nav-link w-nav-link">Hildegard Music Research Guide</a>
-		<a href="mailto:debra.lacoste@dal.ca?subject=DACT%20website%20" class="w-nav-link">Contact us</a>
-	</nav>
       <div class="w-nav-button">
         <div class="w-icon-nav-menu"></div>
-      </div><a href="index.html" class="w-inline-block"><img src="images/DACT-logo-withoutbg.png" width="200" srcset="images/DACT-logo-withoutbg-p-500.png 500w, images/DACT-logo-withoutbg-p-800.png 800w, images/DACT-logo-withoutbg.png 837w" sizes="200px" alt=""></a></div>
+      </div>
+    	<nav role="navigation" class="w-nav-menu">
+      	<a href="index.html" class="nav-link w-nav-link">Home</a>
+      	<div class="dropdown nav-link w-nav-link">
+      	  <button class="dropbtn activities-dropdown-button">
+            Activities ▼
+      	  </button>
+      	  <div class="dropdown-content" id="activitiesDropdown">
+      	    <a href="presentations.html" class="nav-link w-nav-link">Presentations</a>
+      		<a href="publications.html" class="nav-link w-nav-link">Publications</a>
+      		<a href="workshops.html" class="nav-link w-nav-link">Workshops</a>
+      	  </div>
+        	</div>
+      	<a href="projects.html" class="nav-link w-nav-link">Projects</a>
+      	<div class="dropdown nav-link w-nav-link">
+      	  <button class="dropbtn participants-dropdown-button">
+            Participants ▼
+      	  </button>
+      	  <div class="dropdown-content" id="participantsDropdown">
+      	    <a href="partners.html" class="nav-link w-nav-link">Partners</a>
+      		<a href="people.html" class="nav-link w-nav-link">People</a>
+      	  </div>
+        	</div>
+      	<a href="hildegard.html" class="nav-link w-nav-link">Hildegard Music Research Guide</a>
+      	<a href="mailto:debra.lacoste@dal.ca?subject=DACT%20website%20" class="w-nav-link">Contact us</a>
+    	</nav>
+    </div>
   </div>
   <div class="section-2">
     <div class="div-block-3"><img src="images/alina-grubnyak-ZiQkhI7417A-unsplash.jpg" srcset="images/alina-grubnyak-ZiQkhI7417A-unsplash-p-1080.jpeg 1080w, images/alina-grubnyak-ZiQkhI7417A-unsplash-p-1600.jpeg 1600w, images/alina-grubnyak-ZiQkhI7417A-unsplash-p-2000.jpeg 2000w, images/alina-grubnyak-ZiQkhI7417A-unsplash-p-2600.jpeg 2600w, images/alina-grubnyak-ZiQkhI7417A-unsplash-p-3200.jpeg 3200w, images/alina-grubnyak-ZiQkhI7417A-unsplash.jpg 3456w" sizes="(max-width: 3456px) 100vw, 3456px" alt="" class="image-3"></div>

--- a/partners.html
+++ b/partners.html
@@ -1,1 +1,93 @@
-
+<!DOCTYPE html>
+<!--  Last Published: Sun Dec 13 2020 01:01:28 GMT+0000 (Coordinated Universal Time)  -->
+<html data-wf-page="5e0a537f76f1c6e366bd5105" data-wf-site="5e0a44cbad6bad6b2fc1b864">
+<head>
+  <meta charset="utf-8">
+  <title>Partners</title>
+  <meta content="The Digital Analysis of Chant Transmission (DACT) is a partnership project that extends the study of the dissemination of plainchant from localized research focused mostly on Europe and the Middle Ages to global research tracing transmission to other continents through to the modern era." name="description">
+  <meta content="Partners" property="og:title">
+  <meta content="The Digital Analysis of Chant Transmission (DACT) is a partnership project that extends the study of the dissemination of plainchant from localized research focused mostly on Europe and the Middle Ages to global research tracing transmission to other continents through to the modern era." property="og:description">
+  <meta content="summary" name="twitter:card">
+  <meta content="width=device-width, initial-scale=1" name="viewport">
+  <link href="css/normalize.css" rel="stylesheet" type="text/css">
+  <link href="css/webflow.css" rel="stylesheet" type="text/css">
+  <link href="css/dact.webflow.css" rel="stylesheet" type="text/css">
+  <!-- [if lt IE 9]><script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js" type="text/javascript"></script><![endif] -->
+  <script type="text/javascript">!function(o,c){var n=c.documentElement,t=" w-mod-";n.className+=t+"js",("ontouchstart"in o||o.DocumentTouch&&c instanceof DocumentTouch)&&(n.className+=t+"touch")}(window,document);</script>
+  <script src="js/dropdown.js" type="text/javascript"></script>
+  <link href="images/favicon.png" rel="shortcut icon" type="image/x-icon">
+  <link href="images/webclip.png" rel="apple-touch-icon">
+</head>
+<body>
+  <div data-collapse="medium" data-animation="default" data-duration="400" class="w-nav">
+    <div class="w-container">
+      <div class="w-nav-button">
+        <div class="w-icon-nav-menu"></div>
+      </div>
+    	<nav role="navigation" class="w-nav-menu">
+      	<a href="index.html" class="nav-link w-nav-link">Home</a>
+      	<div class="dropdown nav-link w-nav-link">
+      	  <button class="dropbtn activities-dropdown-button">
+            Activities ▼
+      	  </button>
+      	  <div class="dropdown-content" id="activitiesDropdown">
+      	    <a href="presentations.html" class="nav-link w-nav-link">Presentations</a>
+      		<a href="publications.html" class="nav-link w-nav-link">Publications</a>
+      		<a href="workshops.html" class="nav-link w-nav-link">Workshops</a>
+      	  </div>
+        	</div>
+      	<a href="projects.html" class="nav-link w-nav-link">Projects</a>
+      	<div class="dropdown nav-link w-nav-link">
+      	  <button class="dropbtn participants-dropdown-button">
+            Participants ▼
+      	  </button>
+      	  <div class="dropdown-content" id="participantsDropdown">
+      	    <a href="partners.html" class="nav-link w-nav-link">Partners</a>
+      		<a href="people.html" class="nav-link w-nav-link">People</a>
+      	  </div>
+        	</div>
+      	<a href="hildegard.html" class="nav-link w-nav-link">Hildegard Music Research Guide</a>
+      	<a href="mailto:debra.lacoste@dal.ca?subject=DACT%20website%20" class="w-nav-link">Contact us</a>
+    	</nav>
+    </div>
+  </div>
+  <div class="section-2">
+    <div class="div-block-3"><img src="images/alina-grubnyak-ZiQkhI7417A-unsplash.jpg" srcset="images/alina-grubnyak-ZiQkhI7417A-unsplash-p-1080.jpeg 1080w, images/alina-grubnyak-ZiQkhI7417A-unsplash-p-1600.jpeg 1600w, images/alina-grubnyak-ZiQkhI7417A-unsplash-p-2000.jpeg 2000w, images/alina-grubnyak-ZiQkhI7417A-unsplash-p-2600.jpeg 2600w, images/alina-grubnyak-ZiQkhI7417A-unsplash-p-3200.jpeg 3200w, images/alina-grubnyak-ZiQkhI7417A-unsplash.jpg 3456w" sizes="(max-width: 3456px) 100vw, 3456px" alt="" class="image-3"></div>
+    <div>
+      <div class="w-container">
+        <h3 class="heading-7">Partner Organizations</h3>
+      </div>
+    </div>
+  </div>
+  <div class="container-2 w-container">
+    <div class="section-7">
+      <ul class="w-list-unstyled">
+        <li><a href="https://www.dal.ca/" target="_blank">Dalhousie University</a>, Halifax, Nova Scotia, Canada [Host Institution]</li>
+        <li><a href="https://ace-net.ca/" target="_blank">ACENET</a>, Supercomputing in Atlantic Canada</li>
+        <li><a href="https://www.bodleian.ox.ac.uk/home" target="_blank">Bodleian Libraries</a>, University of Oxford, UK</li>
+        <li><a href="https://www.cbu.ca/" target="_blank">Cape Breton University</a>, Sydney, Nova Scotia, Canada</li>
+        <li><a href="https://hmml.org/" target="_blank">Hill Museum and Manuscript Library</a>, Collegeville, Minnesota, USA</li>
+        <li><a href="https://mta.hu/english/" target="_blank">Hungarian Academy of Sciences</a>, Budapest, Hungary, Research Centre for the Humanities, Institute for Musicology</li>
+        <li>McGill University, Montréal, Québec, Canada, <a href="https://www.mcgill.ca/music/" target="_blank">Schulich School of Music</a></li>
+        <li><a href="https://mta.ca/" target="_blank">Mount Allison University</a>, Sackville, New Brunswick, Canada</li>
+        <li>Polish Academy of Sciences, Warszawa, Poland, <a href="http://www.ispan.pl/en" target="_blank">Institute of Art</a></li>
+        <li><a href="https://rism.info/digital-center.html" target="_blank">RISM Digital Center</a>, Bern, Switzerland</li>
+        <li>Slovak Academy of Sciences, <a href="http://uhv.sav.sk/en/" target="_blank">Institute of Musicology</a>, Bratislava, Slovakia</li>
+        <li><a href="https://www.cbu.ca/indigenous-affairs/unamaki-college/" target="_blank">Unama'ki College</a>, Sydney, Nova Scotia, Canada</li>
+        <li><a href="https://www.ucm.es/" target="_blank">Universidad Complutense de Madrid</a>, Spain, <a href="http://musicahispanica.eu" target="_blank">Musica Hispanica / Spanish Early Music Manuscripts</a></li>
+        <li>Universidade NOVA de Lisboa, Faculdade de Ciências Sociais e Humanas, Lisbon, Portugal, <a href="http://cesem.fcsh.unl.pt/" target="_blank">Centro de Estudos de Sociologia e Estética Musical</a>, (Centre for the Study of the Sociology and Aesthetics of Music CESEM)</li>
+        <li><a href="https://www.unifr.ch/" target="_blank">Université de Fribourg</a>, Switzerland, <a href="https://www.e-codices.unifr.ch/en" target="_blank">e-codices</a>, <a href="https://fragmentarium.ms" target="_blank">Fragmentarium</a></li>
+        <li><a href="http://umanitoba.ca/" target="_blank">University of Manitoba</a>, Winnipeg, Manitoba, Canada</li>
+        <li>University of Missouri-Kansas City, USA, <a href="https://daedalus.umkc.edu/CODICES/" target="_blank">CODICES: Digital Humanities Lab</a></li>
+        <li>University of Oslo, Norway, <a href="https://www.hf.uio.no/imv/english/research/projects/benedicamus-domino/" target="_blank">BENEDICAMUS project</a></li>
+	      <li>University of Oxford, UK, <a href="https://www.diamm.ac.uk" target="_blank">DIAMM</a> (the Digital Image Archive of Medieval Music)</li>
+        <li><a href="https://uwaterloo.ca/" target="_blank">University of Waterloo</a>, Ontario, Canada, <a href="https://cantus.uwaterloo.ca" target="_blank">Cantus: A Database for Latin Ecclesiastical Chant</a></li>
+        <li><a href="https://www.wlu.ca" target="_blank">Wilfrid Laurier University</a>, Waterloo, Ontario, Canada</li>
+      </ul>
+    </div>
+  </div>
+  <script src="https://d3e54v103j8qbb.cloudfront.net/js/jquery-3.4.1.min.220afd743d.js" type="text/javascript" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
+  <script src="js/webflow.js" type="text/javascript"></script>
+  <!-- [if lte IE 9]><script src="https://cdnjs.cloudflare.com/ajax/libs/placeholders/3.0.2/placeholders.min.js"></script><![endif] -->
+</body>
+</html>

--- a/partners.html
+++ b/partners.html
@@ -55,11 +55,12 @@
     <div class="div-block-3"><img src="images/alina-grubnyak-ZiQkhI7417A-unsplash.jpg" srcset="images/alina-grubnyak-ZiQkhI7417A-unsplash-p-1080.jpeg 1080w, images/alina-grubnyak-ZiQkhI7417A-unsplash-p-1600.jpeg 1600w, images/alina-grubnyak-ZiQkhI7417A-unsplash-p-2000.jpeg 2000w, images/alina-grubnyak-ZiQkhI7417A-unsplash-p-2600.jpeg 2600w, images/alina-grubnyak-ZiQkhI7417A-unsplash-p-3200.jpeg 3200w, images/alina-grubnyak-ZiQkhI7417A-unsplash.jpg 3456w" sizes="(max-width: 3456px) 100vw, 3456px" alt="" class="image-3"></div>
     <div>
       <div class="w-container">
-        <h3 class="heading-7">Partner Organizations</h3>
+        <h3 class="heading-7">Partners</h3>
       </div>
     </div>
   </div>
   <div class="container-2 w-container">
+    <h4>Partner Organizations</h4>
     <div class="section-7">
       <ul class="w-list-unstyled">
         <li><a href="https://www.dal.ca/" target="_blank">Dalhousie University</a>, Halifax, Nova Scotia, Canada [Host Institution]</li>

--- a/people.html
+++ b/people.html
@@ -3,9 +3,9 @@
 <html data-wf-page="5e0a537f76f1c6e366bd5105" data-wf-site="5e0a44cbad6bad6b2fc1b864">
 <head>
   <meta charset="utf-8">
-  <title>Participants</title>
+  <title>People</title>
   <meta content="The Digital Analysis of Chant Transmission (DACT) is a partnership project that extends the study of the dissemination of plainchant from localized research focused mostly on Europe and the Middle Ages to global research tracing transmission to other continents through to the modern era." name="description">
-  <meta content="Participants" property="og:title">
+  <meta content="People" property="og:title">
   <meta content="The Digital Analysis of Chant Transmission (DACT) is a partnership project that extends the study of the dissemination of plainchant from localized research focused mostly on Europe and the Middle Ages to global research tracing transmission to other continents through to the modern era." property="og:description">
   <meta content="summary" name="twitter:card">
   <meta content="width=device-width, initial-scale=1" name="viewport">
@@ -55,7 +55,7 @@
     <div class="div-block-3"><img src="images/alina-grubnyak-ZiQkhI7417A-unsplash.jpg" srcset="images/alina-grubnyak-ZiQkhI7417A-unsplash-p-1080.jpeg 1080w, images/alina-grubnyak-ZiQkhI7417A-unsplash-p-1600.jpeg 1600w, images/alina-grubnyak-ZiQkhI7417A-unsplash-p-2000.jpeg 2000w, images/alina-grubnyak-ZiQkhI7417A-unsplash-p-2600.jpeg 2600w, images/alina-grubnyak-ZiQkhI7417A-unsplash-p-3200.jpeg 3200w, images/alina-grubnyak-ZiQkhI7417A-unsplash.jpg 3456w" sizes="(max-width: 3456px) 100vw, 3456px" alt="" class="image-3"></div>
     <div>
       <div class="w-container">
-        <h3 class="heading-7">Participants</h3>
+        <h3 class="heading-7">People</h3>
       </div>
     </div>
   </div>
@@ -116,37 +116,11 @@
       <p>Melanie Turgeon<br>The King's University, Edmonton<br></p>
       <p>Hana Vlhová-Wörner<br>Czech Academy of Sciences<br></p>
    </div>
-      <h4>Scientific Advisory Council</h4>
-      <p>David Burn<br>KU Leuven, Belgium</p>
-      <p>Lisa Fagin Davis<br>Medieval Academy of America, USA</p>
-      <p>Dylan Robinson<br>University of British Columbia</p><br><br>
+  <h4>Scientific Advisory Council</h4>
+  <p>David Burn<br>KU Leuven, Belgium</p>
+  <p>Lisa Fagin Davis<br>Medieval Academy of America, USA</p>
+  <p>Dylan Robinson<br>University of British Columbia</p><br><br>
  
-    <div class="section-7">
-      <h4 class="heading-3">Partner Organizations</h4>
-      <ul class="w-list-unstyled">
-        <li><a href="https://www.dal.ca/" target="_blank">Dalhousie University</a>, Halifax, Nova Scotia, Canada [Host Institution]</li>
-        <li><a href="https://ace-net.ca/" target="_blank">ACENET</a>, Supercomputing in Atlantic Canada</li>
-        <li><a href="https://www.bodleian.ox.ac.uk/home" target="_blank">Bodleian Libraries</a>, University of Oxford, UK</li>
-        <li><a href="https://www.cbu.ca/" target="_blank">Cape Breton University</a>, Sydney, Nova Scotia, Canada</li>
-        <li><a href="https://hmml.org/" target="_blank">Hill Museum and Manuscript Library</a>, Collegeville, Minnesota, USA</li>
-        <li><a href="https://mta.hu/english/" target="_blank">Hungarian Academy of Sciences</a>, Budapest, Hungary, Research Centre for the Humanities, Institute for Musicology</li>
-        <li>McGill University, Montréal, Québec, Canada, <a href="https://www.mcgill.ca/music/" target="_blank">Schulich School of Music</a></li>
-        <li><a href="https://mta.ca/" target="_blank">Mount Allison University</a>, Sackville, New Brunswick, Canada</li>
-        <li>Polish Academy of Sciences, Warszawa, Poland, <a href="http://www.ispan.pl/en" target="_blank">Institute of Art</a></li>
-        <li><a href="https://rism.info/digital-center.html" target="_blank">RISM Digital Center</a>, Bern, Switzerland</li>
-        <li>Slovak Academy of Sciences, <a href="http://uhv.sav.sk/en/" target="_blank">Institute of Musicology</a>, Bratislava, Slovakia</li>
-        <li><a href="https://www.cbu.ca/indigenous-affairs/unamaki-college/" target="_blank">Unama'ki College</a>, Sydney, Nova Scotia, Canada</li>
-        <li><a href="https://www.ucm.es/" target="_blank">Universidad Complutense de Madrid</a>, Spain, <a href="http://musicahispanica.eu" target="_blank">Musica Hispanica / Spanish Early Music Manuscripts</a></li>
-        <li>Universidade NOVA de Lisboa, Faculdade de Ciências Sociais e Humanas, Lisbon, Portugal, <a href="http://cesem.fcsh.unl.pt/" target="_blank">Centro de Estudos de Sociologia e Estética Musical</a>, (Centre for the Study of the Sociology and Aesthetics of Music CESEM)</li>
-        <li><a href="https://www.unifr.ch/" target="_blank">Université de Fribourg</a>, Switzerland, <a href="https://www.e-codices.unifr.ch/en" target="_blank">e-codices</a>, <a href="https://fragmentarium.ms" target="_blank">Fragmentarium</a></li>
-        <li><a href="http://umanitoba.ca/" target="_blank">University of Manitoba</a>, Winnipeg, Manitoba, Canada</li>
-        <li>University of Missouri-Kansas City, USA, <a href="https://daedalus.umkc.edu/CODICES/" target="_blank">CODICES: Digital Humanities Lab</a></li>
-        <li>University of Oslo, Norway, <a href="https://www.hf.uio.no/imv/english/research/projects/benedicamus-domino/" target="_blank">BENEDICAMUS project</a></li>
-	<li>University of Oxford, UK, <a href="https://www.diamm.ac.uk" target="_blank">DIAMM</a> (the Digital Image Archive of Medieval Music)</li>
-        <li><a href="https://uwaterloo.ca/" target="_blank">University of Waterloo</a>, Ontario, Canada, <a href="https://cantus.uwaterloo.ca" target="_blank">Cantus: A Database for Latin Ecclesiastical Chant</a></li>
-          <li><a href="https://www.wlu.ca" target="_blank">Wilfrid Laurier University</a>, Waterloo, Ontario, Canada</li>
-      </ul>
-    </div>
   </div>
   <script src="https://d3e54v103j8qbb.cloudfront.net/js/jquery-3.4.1.min.220afd743d.js" type="text/javascript" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
   <script src="js/webflow.js" type="text/javascript"></script>

--- a/presentations.html
+++ b/presentations.html
@@ -14,38 +14,43 @@
 	<link href="css/dact.webflow.css" rel="stylesheet" type="text/css">
 	<!-- [if lt IE 9]><script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js" type="text/javascript"></script><![endif] -->
 	<script type="text/javascript">!function(o,c){var n=c.documentElement,t=" w-mod-";n.className+=t+"js",("ontouchstart"in o||o.DocumentTouch&&c instanceof DocumentTouch)&&(n.className+=t+"touch")}(window,document);</script>
+  <script src="js/dropdown.js" type="text/javascript"></script>
 	<link href="images/favicon.png" rel="shortcut icon" type="image/x-icon">
 	<link href="images/webclip.png" rel="apple-touch-icon">
 </head>
 <body>
-	<div data-collapse="medium" data-animation="default" data-duration="400" class="w-nav">
-		<div class="w-container">
-			<div class="w-nav-button">
-				<div class="w-icon-nav-menu"></div>
-			</div>
-			<nav role="navigation" class="w-nav-menu">
-				<a href="index.html" class="nav-link w-nav-link">Home</a>
-				<div class="dropdown nav-link w-nav-link">
-				  <button class="dropbtn" onclick="toggleDropdown()">
-					Activities ▼
-				  </button>
-				  <div class="dropdown-content" id="activitiesDropdown">
-				    <a href="presentations.html" class="nav-link w-nav-link">Presentations</a>
-					<a href="publications.html" class="nav-link w-nav-link">Publications</a>
-					<a href="workshops.html" class="nav-link w-nav-link">Workshops</a>
-				  </div>
-			  	</div>
-				<script src="js/dropdown.js" type="text/javascript"></script>
-				<a href="projects.html" class="nav-link w-nav-link">Projects</a>
-				<a href="participants.html" class="nav-link w-nav-link">Participants</a>
-				<a href="hildegard.html" class="nav-link w-nav-link">Hildegard Music Research Guide</a>
-				<a href="mailto:debra.lacoste@dal.ca?subject=DACT%20website%20" class="w-nav-link">Contact us</a>
-			</nav>
-			<a href="index.html" class="w-inline-block">
-				<img src="images/DACT-logo-withoutbg.png" width="200" srcset="images/DACT-logo-withoutbg-p-500.png 500w, images/DACT-logo-withoutbg-p-800.png 800w, images/DACT-logo-withoutbg.png 837w" sizes="200px" alt="">
-			</a>
-		</div>
-	</div>
+  <div data-collapse="medium" data-animation="default" data-duration="400" class="w-nav">
+    <div class="w-container">
+      <div class="w-nav-button">
+        <div class="w-icon-nav-menu"></div>
+      </div>
+    	<nav role="navigation" class="w-nav-menu">
+      	<a href="index.html" class="nav-link w-nav-link">Home</a>
+      	<div class="dropdown nav-link w-nav-link">
+      	  <button class="dropbtn activities-dropdown-button">
+            Activities ▼
+      	  </button>
+      	  <div class="dropdown-content" id="activitiesDropdown">
+      	    <a href="presentations.html" class="nav-link w-nav-link">Presentations</a>
+      		<a href="publications.html" class="nav-link w-nav-link">Publications</a>
+      		<a href="workshops.html" class="nav-link w-nav-link">Workshops</a>
+      	  </div>
+        	</div>
+      	<a href="projects.html" class="nav-link w-nav-link">Projects</a>
+      	<div class="dropdown nav-link w-nav-link">
+      	  <button class="dropbtn participants-dropdown-button">
+            Participants ▼
+      	  </button>
+      	  <div class="dropdown-content" id="participantsDropdown">
+      	    <a href="partners.html" class="nav-link w-nav-link">Partners</a>
+      		<a href="people.html" class="nav-link w-nav-link">People</a>
+      	  </div>
+        	</div>
+      	<a href="hildegard.html" class="nav-link w-nav-link">Hildegard Music Research Guide</a>
+      	<a href="mailto:debra.lacoste@dal.ca?subject=DACT%20website%20" class="w-nav-link">Contact us</a>
+    	</nav>
+    </div>
+  </div>
 	<div class="section-2">
 		<div class="div-block-3"><img src="images/alina-grubnyak-ZiQkhI7417A-unsplash.jpg" srcset="images/alina-grubnyak-ZiQkhI7417A-unsplash-p-1080.jpeg 1080w, images/alina-grubnyak-ZiQkhI7417A-unsplash-p-1600.jpeg 1600w, images/alina-grubnyak-ZiQkhI7417A-unsplash-p-2000.jpeg 2000w, images/alina-grubnyak-ZiQkhI7417A-unsplash-p-2600.jpeg 2600w, images/alina-grubnyak-ZiQkhI7417A-unsplash-p-3200.jpeg 3200w, images/alina-grubnyak-ZiQkhI7417A-unsplash.jpg 3456w" sizes="(max-width: 3456px) 100vw, 3456px" alt="" class="image-3"></div>
 		<div>

--- a/projects.html
+++ b/projects.html
@@ -14,6 +14,7 @@
   <link href="css/dact.webflow.css" rel="stylesheet" type="text/css">
   <!-- [if lt IE 9]><script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js" type="text/javascript"></script><![endif] -->
   <script type="text/javascript">!function(o,c){var n=c.documentElement,t=" w-mod-";n.className+=t+"js",("ontouchstart"in o||o.DocumentTouch&&c instanceof DocumentTouch)&&(n.className+=t+"touch")}(window,document);</script>
+  <script src="js/dropdown.js" type="text/javascript"></script>
   <link href="images/favicon.png" rel="shortcut icon" type="image/x-icon">
   <link href="images/webclip.png" rel="apple-touch-icon">
 </head>
@@ -23,25 +24,32 @@
       <div class="w-nav-button">
         <div class="w-icon-nav-menu"></div>
       </div>
-	<nav role="navigation" class="w-nav-menu">
-		<a href="index.html" class="nav-link w-nav-link">Home</a>
-		<div class="dropdown nav-link w-nav-link">
-		  <button class="dropbtn" onclick="toggleDropdown()">
-			Activities ▼
-		  </button>
-		  <div class="dropdown-content" id="activitiesDropdown">
-		    <a href="presentations.html" class="nav-link w-nav-link">Presentations</a>
-			<a href="publications.html" class="nav-link w-nav-link">Publications</a>
-			<a href="workshops.html" class="nav-link w-nav-link">Workshops</a>
-		  </div>
-	  	</div>
-		<script src="js/dropdown.js" type="text/javascript"></script>
-		<a href="projects.html" class="nav-link w-nav-link">Projects</a>
-		<a href="participants.html" class="nav-link w-nav-link">Participants</a>
-		<a href="hildegard.html" class="nav-link w-nav-link">Hildegard Music Research Guide</a>
-		<a href="mailto:debra.lacoste@dal.ca?subject=DACT%20website%20" class="w-nav-link">Contact us</a>
-	</nav>
-      <a href="index.html" class="w-inline-block"><img src="images/DACT-logo-withoutbg.png" width="200" srcset="images/DACT-logo-withoutbg-p-500.png 500w, images/DACT-logo-withoutbg-p-800.png 800w, images/DACT-logo-withoutbg.png 837w" sizes="200px" alt=""></a></div>
+    	<nav role="navigation" class="w-nav-menu">
+      	<a href="index.html" class="nav-link w-nav-link">Home</a>
+      	<div class="dropdown nav-link w-nav-link">
+      	  <button class="dropbtn activities-dropdown-button">
+            Activities ▼
+      	  </button>
+      	  <div class="dropdown-content" id="activitiesDropdown">
+      	    <a href="presentations.html" class="nav-link w-nav-link">Presentations</a>
+      		<a href="publications.html" class="nav-link w-nav-link">Publications</a>
+      		<a href="workshops.html" class="nav-link w-nav-link">Workshops</a>
+      	  </div>
+        	</div>
+      	<a href="projects.html" class="nav-link w-nav-link">Projects</a>
+      	<div class="dropdown nav-link w-nav-link">
+      	  <button class="dropbtn participants-dropdown-button">
+            Participants ▼
+      	  </button>
+      	  <div class="dropdown-content" id="participantsDropdown">
+      	    <a href="partners.html" class="nav-link w-nav-link">Partners</a>
+      		<a href="people.html" class="nav-link w-nav-link">People</a>
+      	  </div>
+        	</div>
+      	<a href="hildegard.html" class="nav-link w-nav-link">Hildegard Music Research Guide</a>
+      	<a href="mailto:debra.lacoste@dal.ca?subject=DACT%20website%20" class="w-nav-link">Contact us</a>
+    	</nav>
+    </div>
   </div>
   <div class="section-2">
     <div class="div-block-3"><img src="images/alina-grubnyak-ZiQkhI7417A-unsplash.jpg" srcset="images/alina-grubnyak-ZiQkhI7417A-unsplash-p-1080.jpeg 1080w, images/alina-grubnyak-ZiQkhI7417A-unsplash-p-1600.jpeg 1600w, images/alina-grubnyak-ZiQkhI7417A-unsplash-p-2000.jpeg 2000w, images/alina-grubnyak-ZiQkhI7417A-unsplash-p-2600.jpeg 2600w, images/alina-grubnyak-ZiQkhI7417A-unsplash-p-3200.jpeg 3200w, images/alina-grubnyak-ZiQkhI7417A-unsplash.jpg 3456w" sizes="(max-width: 3456px) 100vw, 3456px" alt="" class="image-3"></div>

--- a/publications.html
+++ b/publications.html
@@ -14,38 +14,43 @@
 	<link href="css/dact.webflow.css" rel="stylesheet" type="text/css">
 	<!-- [if lt IE 9]><script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js" type="text/javascript"></script><![endif] -->
 	<script type="text/javascript">!function(o,c){var n=c.documentElement,t=" w-mod-";n.className+=t+"js",("ontouchstart"in o||o.DocumentTouch&&c instanceof DocumentTouch)&&(n.className+=t+"touch")}(window,document);</script>
+  <script src="js/dropdown.js" type="text/javascript"></script>
 	<link href="images/favicon.png" rel="shortcut icon" type="image/x-icon">
 	<link href="images/webclip.png" rel="apple-touch-icon">
 </head>
 <body>
-	<div data-collapse="medium" data-animation="default" data-duration="400" class="w-nav">
-		<div class="w-container">
-			<div class="w-nav-button">
-				<div class="w-icon-nav-menu"></div>
-			</div>
-			<nav role="navigation" class="w-nav-menu">
-				<a href="index.html" class="nav-link w-nav-link">Home</a>
-				<div class="dropdown nav-link w-nav-link">
-				  <button class="dropbtn" onclick="toggleDropdown()">
-					Activities ▼
-				  </button>
-				  <div class="dropdown-content" id="activitiesDropdown">
-				    <a href="presentations.html" class="nav-link w-nav-link">Presentations</a>
-					<a href="publications.html" class="nav-link w-nav-link">Publications</a>
-					<a href="workshops.html" class="nav-link w-nav-link">Workshops</a>
-				  </div>
-			  	</div>
-				<script src="js/dropdown.js" type="text/javascript"></script>
-				<a href="projects.html" class="nav-link w-nav-link">Projects</a>
-				<a href="participants.html" class="nav-link w-nav-link">Participants</a>
-				<a href="hildegard.html" class="nav-link w-nav-link">Hildegard Music Research Guide</a>
-				<a href="mailto:debra.lacoste@dal.ca?subject=DACT%20website%20" class="w-nav-link">Contact us</a>
-			</nav>
-			<a href="index.html" class="w-inline-block">
-				<img src="images/DACT-logo-withoutbg.png" width="200" srcset="images/DACT-logo-withoutbg-p-500.png 500w, images/DACT-logo-withoutbg-p-800.png 800w, images/DACT-logo-withoutbg.png 837w" sizes="200px" alt="">
-			</a>
-		</div>
-	</div>
+  <div data-collapse="medium" data-animation="default" data-duration="400" class="w-nav">
+    <div class="w-container">
+      <div class="w-nav-button">
+        <div class="w-icon-nav-menu"></div>
+      </div>
+    	<nav role="navigation" class="w-nav-menu">
+      	<a href="index.html" class="nav-link w-nav-link">Home</a>
+      	<div class="dropdown nav-link w-nav-link">
+      	  <button class="dropbtn activities-dropdown-button">
+            Activities ▼
+      	  </button>
+      	  <div class="dropdown-content" id="activitiesDropdown">
+      	    <a href="presentations.html" class="nav-link w-nav-link">Presentations</a>
+      		<a href="publications.html" class="nav-link w-nav-link">Publications</a>
+      		<a href="workshops.html" class="nav-link w-nav-link">Workshops</a>
+      	  </div>
+        	</div>
+      	<a href="projects.html" class="nav-link w-nav-link">Projects</a>
+      	<div class="dropdown nav-link w-nav-link">
+      	  <button class="dropbtn participants-dropdown-button">
+            Participants ▼
+      	  </button>
+      	  <div class="dropdown-content" id="participantsDropdown">
+      	    <a href="partners.html" class="nav-link w-nav-link">Partners</a>
+      		<a href="people.html" class="nav-link w-nav-link">People</a>
+      	  </div>
+        	</div>
+      	<a href="hildegard.html" class="nav-link w-nav-link">Hildegard Music Research Guide</a>
+      	<a href="mailto:debra.lacoste@dal.ca?subject=DACT%20website%20" class="w-nav-link">Contact us</a>
+    	</nav>
+    </div>
+  </div>
 	<div class="section-2">
 		<div class="div-block-3"><img src="images/alina-grubnyak-ZiQkhI7417A-unsplash.jpg" srcset="images/alina-grubnyak-ZiQkhI7417A-unsplash-p-1080.jpeg 1080w, images/alina-grubnyak-ZiQkhI7417A-unsplash-p-1600.jpeg 1600w, images/alina-grubnyak-ZiQkhI7417A-unsplash-p-2000.jpeg 2000w, images/alina-grubnyak-ZiQkhI7417A-unsplash-p-2600.jpeg 2600w, images/alina-grubnyak-ZiQkhI7417A-unsplash-p-3200.jpeg 3200w, images/alina-grubnyak-ZiQkhI7417A-unsplash.jpg 3456w" sizes="(max-width: 3456px) 100vw, 3456px" alt="" class="image-3"></div>
 		<div>

--- a/workshops.html
+++ b/workshops.html
@@ -14,38 +14,43 @@
 	<link href="css/dact.webflow.css" rel="stylesheet" type="text/css">
 	<!-- [if lt IE 9]><script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js" type="text/javascript"></script><![endif] -->
 	<script type="text/javascript">!function(o,c){var n=c.documentElement,t=" w-mod-";n.className+=t+"js",("ontouchstart"in o||o.DocumentTouch&&c instanceof DocumentTouch)&&(n.className+=t+"touch")}(window,document);</script>
+  <script src="js/dropdown.js" type="text/javascript"></script>
 	<link href="images/favicon.png" rel="shortcut icon" type="image/x-icon">
 	<link href="images/webclip.png" rel="apple-touch-icon">
 </head>
 <body>
-	<div data-collapse="medium" data-animation="default" data-duration="400" class="w-nav">
-		<div class="w-container">
-			<div class="w-nav-button">
-				<div class="w-icon-nav-menu"></div>
-			</div>
-			<nav role="navigation" class="w-nav-menu">
-				<a href="index.html" class="nav-link w-nav-link">Home</a>
-				<div class="dropdown nav-link w-nav-link">
-				  <button class="dropbtn" onclick="toggleDropdown()">
-					Activities ▼
-				  </button>
-				  <div class="dropdown-content" id="activitiesDropdown">
-				    <a href="presentations.html" class="nav-link w-nav-link">Presentations</a>
-					<a href="publications.html" class="nav-link w-nav-link">Publications</a>
-					<a href="workshops.html" class="nav-link w-nav-link">Workshops</a>
-				  </div>
-			  	</div>
-				<script src="js/dropdown.js" type="text/javascript"></script>
-				<a href="projects.html" class="nav-link w-nav-link">Projects</a>
-				<a href="participants.html" class="nav-link w-nav-link">Participants</a>
-				<a href="hildegard.html" class="nav-link w-nav-link">Hildegard Music Research Guide</a>
-				<a href="mailto:debra.lacoste@dal.ca?subject=DACT%20website%20" class="w-nav-link">Contact us</a>
-			</nav>
-			<a href="index.html" class="w-inline-block">
-				<img src="images/DACT-logo-withoutbg.png" width="200" srcset="images/DACT-logo-withoutbg-p-500.png 500w, images/DACT-logo-withoutbg-p-800.png 800w, images/DACT-logo-withoutbg.png 837w" sizes="200px" alt="">
-			</a>
-		</div>
-	</div>
+  <div data-collapse="medium" data-animation="default" data-duration="400" class="w-nav">
+    <div class="w-container">
+      <div class="w-nav-button">
+        <div class="w-icon-nav-menu"></div>
+      </div>
+    	<nav role="navigation" class="w-nav-menu">
+      	<a href="index.html" class="nav-link w-nav-link">Home</a>
+      	<div class="dropdown nav-link w-nav-link">
+      	  <button class="dropbtn activities-dropdown-button">
+            Activities ▼
+      	  </button>
+      	  <div class="dropdown-content" id="activitiesDropdown">
+      	    <a href="presentations.html" class="nav-link w-nav-link">Presentations</a>
+      		<a href="publications.html" class="nav-link w-nav-link">Publications</a>
+      		<a href="workshops.html" class="nav-link w-nav-link">Workshops</a>
+      	  </div>
+        	</div>
+      	<a href="projects.html" class="nav-link w-nav-link">Projects</a>
+      	<div class="dropdown nav-link w-nav-link">
+      	  <button class="dropbtn participants-dropdown-button">
+            Participants ▼
+      	  </button>
+      	  <div class="dropdown-content" id="participantsDropdown">
+      	    <a href="partners.html" class="nav-link w-nav-link">Partners</a>
+      		<a href="people.html" class="nav-link w-nav-link">People</a>
+      	  </div>
+        	</div>
+      	<a href="hildegard.html" class="nav-link w-nav-link">Hildegard Music Research Guide</a>
+      	<a href="mailto:debra.lacoste@dal.ca?subject=DACT%20website%20" class="w-nav-link">Contact us</a>
+    	</nav>
+    </div>
+  </div>
 	<div class="section-2">
 		<div class="div-block-3"><img src="images/alina-grubnyak-ZiQkhI7417A-unsplash.jpg" srcset="images/alina-grubnyak-ZiQkhI7417A-unsplash-p-1080.jpeg 1080w, images/alina-grubnyak-ZiQkhI7417A-unsplash-p-1600.jpeg 1600w, images/alina-grubnyak-ZiQkhI7417A-unsplash-p-2000.jpeg 2000w, images/alina-grubnyak-ZiQkhI7417A-unsplash-p-2600.jpeg 2600w, images/alina-grubnyak-ZiQkhI7417A-unsplash-p-3200.jpeg 3200w, images/alina-grubnyak-ZiQkhI7417A-unsplash.jpg 3456w" sizes="(max-width: 3456px) 100vw, 3456px" alt="" class="image-3"></div>
 		<div>


### PR DESCRIPTION
This pull request removes the Participants page, splitting its content into two new pages, Partners and People. It adds an additional dropdown menu to the navbar at the top of each page, allowing both of these pages to be accessed.

The new Partners page looks like this:
![Screen Shot 2023-09-25 at 18 00 03](https://github.com/dact-chant/dact-chant.github.io/assets/58090591/0794657c-10a4-4794-93fe-9a0b3579a655)

And the new People page looks like this:
![Screen Shot 2023-09-25 at 18 00 20](https://github.com/dact-chant/dact-chant.github.io/assets/58090591/158882f9-8932-46e0-9cb5-eac495d86bbe)
