### PR TITLE
Add margin to all pages

### DIFF
--- a/css/dact.webflow.css
+++ b/css/dact.webflow.css
@@ -25,6 +25,10 @@ li {
   white-space: normal;
 }
 
+.w-container {
+  padding: 0 8px;
+}
+
 .heading {
   color: #8d2325;
   font-size: 26px;


### PR DESCRIPTION
This PR adds a narrow strip of padding to all pages so that content does not run up against the edge of the screen when the window is narrow.

Previously:
![Screen Shot 2023-09-27 at 12 07 59](https://github.com/dact-chant/dact-chant.github.io/assets/58090591/70600f74-5ba1-4690-89b4-575bc3d8b8de)

Now:
![Screen Shot 2023-09-27 at 12 07 31](https://github.com/dact-chant/dact-chant.github.io/assets/58090591/58bee124-dd54-4d19-a651-3c1837f6a8df)
