### PR TITLE
Create symposia.html

### DIFF
--- a/Namur.html
+++ b/Namur.html
@@ -33,6 +33,7 @@
       	    <a href="presentations.html" class="nav-link w-nav-link">Presentations</a>
       		<a href="publications.html" class="nav-link w-nav-link">Publications</a>
       		<a href="workshops.html" class="nav-link w-nav-link">Workshops</a>
+      		<a href="symposia.html" class="nav-link w-nav-link">Symposia</a>
       	  </div>
         	</div>
       	<a href="projects.html" class="nav-link w-nav-link">Projects</a>

--- a/hildegard.html
+++ b/hildegard.html
@@ -34,6 +34,7 @@
       	    <a href="presentations.html" class="nav-link w-nav-link">Presentations</a>
       		<a href="publications.html" class="nav-link w-nav-link">Publications</a>
       		<a href="workshops.html" class="nav-link w-nav-link">Workshops</a>
+      		<a href="symposia.html" class="nav-link w-nav-link">Symposia</a>
       	  </div>
         	</div>
       	<a href="projects.html" class="nav-link w-nav-link">Projects</a>

--- a/index.html
+++ b/index.html
@@ -34,6 +34,7 @@
       	    <a href="presentations.html" class="nav-link w-nav-link">Presentations</a>
       		<a href="publications.html" class="nav-link w-nav-link">Publications</a>
       		<a href="workshops.html" class="nav-link w-nav-link">Workshops</a>
+      		<a href="symposia.html" class="nav-link w-nav-link">Symposia</a>
       	  </div>
         	</div>
       	<a href="projects.html" class="nav-link w-nav-link">Projects</a>

--- a/partners.html
+++ b/partners.html
@@ -34,6 +34,7 @@
       	    <a href="presentations.html" class="nav-link w-nav-link">Presentations</a>
       		<a href="publications.html" class="nav-link w-nav-link">Publications</a>
       		<a href="workshops.html" class="nav-link w-nav-link">Workshops</a>
+      		<a href="symposia.html" class="nav-link w-nav-link">Symposia</a>
       	  </div>
         	</div>
       	<a href="projects.html" class="nav-link w-nav-link">Projects</a>

--- a/people.html
+++ b/people.html
@@ -34,6 +34,7 @@
       	    <a href="presentations.html" class="nav-link w-nav-link">Presentations</a>
       		<a href="publications.html" class="nav-link w-nav-link">Publications</a>
       		<a href="workshops.html" class="nav-link w-nav-link">Workshops</a>
+      		<a href="symposia.html" class="nav-link w-nav-link">Symposia</a>
       	  </div>
         	</div>
       	<a href="projects.html" class="nav-link w-nav-link">Projects</a>

--- a/presentations.html
+++ b/presentations.html
@@ -34,6 +34,7 @@
       	    <a href="presentations.html" class="nav-link w-nav-link">Presentations</a>
       		<a href="publications.html" class="nav-link w-nav-link">Publications</a>
       		<a href="workshops.html" class="nav-link w-nav-link">Workshops</a>
+      		<a href="symposia.html" class="nav-link w-nav-link">Symposia</a>
       	  </div>
         	</div>
       	<a href="projects.html" class="nav-link w-nav-link">Projects</a>

--- a/presentations.html
+++ b/presentations.html
@@ -61,8 +61,7 @@
 		</div>
 	</div>
 	<div class="container-6 w-container">
-		<h2> Past Presentations </h2>
-		<h4 id="2023">2023</h4>
+		<h3 id="2023">2023</h3>
 		<div class="text-block-4">
 			<strong>November 10, 2023</strong>
 			<br>
@@ -185,7 +184,7 @@
 			<br>
 		</div>
 		<hr>
-		<h4 id="2022">2022</h4>
+		<h3 id="2022">2022</h3>
 		<div class="text-block-4">
 			<strong>November 18, 2022</strong>
 			<br>
@@ -256,7 +255,7 @@
 			<br>
 		</div>
 		<hr>
-		<h4 id="2021">2021</h4>
+		<h3 id="2021">2021</h3>
 		<div class="text-block-4">
 			<strong>July 23, 2021</strong>
 			<br>
@@ -338,7 +337,7 @@
 			<br>
 		</div>
 		<hr>
-		<h4 id="2020">2020</h4>
+		<h3 id="2020">2020</h3>
 		<div class="text-block-4">
 			<strong>planned for July 15-19, 2020 [COVID CANCELLATION]</strong>
 			<br>
@@ -380,7 +379,7 @@
 			<br>
 		</div>
 		<hr>
-		<h4 id="2019">2019</h4>
+		<h3 id="2019">2019</h3>
 		<div class="text-block-4">
 			<strong>October 18, 2019</strong>
 			<br>

--- a/presentations.html
+++ b/presentations.html
@@ -60,24 +60,6 @@
 		</div>
 	</div>
 	<div class="container-6 w-container">
-		<h2>Upcoming Symposium in Namur, Belgium</h2>
-		<div class="text-block-4">
-
-			<strong>December 1, 2023</strong>
-			<br>
-			(postponed from October 24, 2020)
-			<br>
-			Namur University, Belgium
-			<br>
-			Celebrating Salzinnes: A Symposium
-			<br>
-			A one-day symposium of papers and panel discussions by international scholars on topics related to the Salzinnes Antiphonal, developments in digital technology, and manuscript studies. Includes a tour through the “Centuries of Silence” exhibition at the Musée des Arts Anciens and a concert of some of the music contained in the manuscript.
-			<br>
-			<br>
-			<h4> <a href="Namur.html" target="_blank">Program and presenters.</a></h4>
-		</div>
-		<hr>
-
 		<h2> Past Presentations </h2>
 		<h4 id="2023">2023</h4>
 		<div class="text-block-4">

--- a/projects.html
+++ b/projects.html
@@ -34,6 +34,7 @@
       	    <a href="presentations.html" class="nav-link w-nav-link">Presentations</a>
       		<a href="publications.html" class="nav-link w-nav-link">Publications</a>
       		<a href="workshops.html" class="nav-link w-nav-link">Workshops</a>
+      		<a href="symposia.html" class="nav-link w-nav-link">Symposia</a>
       	  </div>
         	</div>
       	<a href="projects.html" class="nav-link w-nav-link">Projects</a>

--- a/publications.html
+++ b/publications.html
@@ -61,7 +61,7 @@
 		</div>
 	</div>
 	<div class="container-6 w-container">
-		<h2 id="2022">2022</h2>
+		<h3 id="2022">2022</h3>
 		<div class="text-block-4">
 			de Bakker, Anna; and Kennedy, Kathleen E. 2022. "The Charterhouse Antiphonal Fragment." <i>Manuscript Studies: A Journal of the Schoenberg Institute for Manuscript Studies</i> 7, no. 1: 175-186. <a href="https://doi.org/10.1353/mns.2022.0004" target="_blank">doi:10.1353/mns.2022.0004.</a> (also: <a href="https://muse.jhu.edu/article/856951" target="_blank">https://muse.jhu.edu/article/856951</a>)
 			<br>
@@ -71,7 +71,7 @@
 			<br>
 		</div>
 		<hr>
-		<h2 id="2021">2021</h2>
+		<h3 id="2021">2021</h3>
 		<div class="text-block-4">
 			de Bakker, Anna; and Bain, Jennifer. 2021. "From scribe to choir to being repurposed over generations, medieval Christian chant book fragments reveal stories." <i>The Conversation.</i> Dec 21, 2021. Available <a href="https://theconversation.com/from-scribe-to-choir-to-being-repurposed-over-generations-medieval-christian-chant-book-fragments-reveal-stories-164035" target="_blank">online.</a>
 			<br>
@@ -84,7 +84,7 @@
 			<br>
 		</div>
 		<hr>
-		<h2 id="2020">2020</h2>
+		<h3 id="2020">2020</h3>
 		<div class="text-block-4">
 			Lacoste, Debra. 2020. “Cantus Database—How To … Write a Manuscript Description for a Cantus Database Inventory.” <i>Cantus: A Database for Latin Ecclesiastical Chant.</i> Last Update: 20 Nov 2020. Available from <a href="https://cantusdatabase.org/documents" target="_blank">https://cantusdatabase.org/documents.</a>
 			<br>
@@ -100,7 +100,7 @@
 			<br>
 		</div>
 		<hr>
-		<h2 id="2019">2019</h2>
+		<h3 id="2019">2019</h3>
 		<div class="text-block-4">
 			De Luca, Elsa (Lead Author); Bain, Jennifer; Behrendt, Inga; Fujinaga, Ichiro; Helsen, Kate; Ignesti, Alessandra; Lacoste, Debra; and Long, Sarah Ann. 2019. “Cantus Ultimus' MEI Neume Module and its Interoperability Across Chant Notations.” Presented at the Music Encoding Conference, Vienna, Austria, May 29-June 1, 2019. <i>Music Encoding Conference Proceedings.</i> Semantic Scholar Corpus ID: 226868843: <a href="https://www.semanticscholar.org/paper/Cantus-Ultimus’-MEI-Neume-Module-and-its-Across-Luca-Bain/ef73c4ac59d32404517be1f931d24a08b72cf919" target="_blank">https://www.semanticscholar.org/paper/Cantus-Ultimus’-MEI-Neume-Module-and-its-Across-Luca-Bain/ef73c4ac59d32404517be1f931d24a08b72cf919</a>.
 			<br>

--- a/publications.html
+++ b/publications.html
@@ -34,6 +34,7 @@
       	    <a href="presentations.html" class="nav-link w-nav-link">Presentations</a>
       		<a href="publications.html" class="nav-link w-nav-link">Publications</a>
       		<a href="workshops.html" class="nav-link w-nav-link">Workshops</a>
+      		<a href="symposia.html" class="nav-link w-nav-link">Symposia</a>
       	  </div>
         	</div>
       	<a href="projects.html" class="nav-link w-nav-link">Projects</a>

--- a/symposia.html
+++ b/symposia.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html data-wf-page="5e38e4627d729a58e07ee8ff" data-wf-site="5e0a44cbad6bad6b2fc1b864">
+<head>
+	<meta charset="utf-8">
+	<title>Symposia</title>
+	<meta content="The Digital Analysis of Chant Transmission (DACT) is a partnership project that extends the study of the dissemination of plainchant from localized research focused mostly on Europe and the Middle Ages to global research tracing transmission to other continents through to the modern era." name="description">
+	<meta content="Activities" property="og:title">
+	<meta content="The Digital Analysis of Chant Transmission (DACT) is a partnership project that extends the study of the dissemination of plainchant from localized research focused mostly on Europe and the Middle Ages to global research tracing transmission to other continents through to the modern era." property="og:description">
+	<meta content="summary" name="twitter:card">
+	<meta content="width=device-width, initial-scale=1" name="viewport">
+	<link href="css/normalize.css" rel="stylesheet" type="text/css">
+	<link href="css/webflow.css" rel="stylesheet" type="text/css">
+	<link href="css/dact.webflow.css" rel="stylesheet" type="text/css">
+	<!-- [if lt IE 9]><script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js" type="text/javascript"></script><![endif] -->
+	<script type="text/javascript">!function(o,c){var n=c.documentElement,t=" w-mod-";n.className+=t+"js",("ontouchstart"in o||o.DocumentTouch&&c instanceof DocumentTouch)&&(n.className+=t+"touch")}(window,document);</script>
+  <script src="js/dropdown.js" type="text/javascript"></script>
+	<link href="images/favicon.png" rel="shortcut icon" type="image/x-icon">
+	<link href="images/webclip.png" rel="apple-touch-icon">
+</head>
+<body>
+  <div data-collapse="medium" data-animation="default" data-duration="400" class="w-nav">
+    <div class="w-container">
+      <div class="w-nav-button">
+        <div class="w-icon-nav-menu"></div>
+      </div>
+    	<nav role="navigation" class="w-nav-menu">
+      	<a href="index.html" class="nav-link w-nav-link">Home</a>
+      	<div class="dropdown nav-link w-nav-link">
+      	  <button class="dropbtn activities-dropdown-button">
+            Activities ▼
+      	  </button>
+      	  <div class="dropdown-content" id="activitiesDropdown">
+      	    <a href="presentations.html" class="nav-link w-nav-link">Presentations</a>
+      		<a href="publications.html" class="nav-link w-nav-link">Publications</a>
+      		<a href="workshops.html" class="nav-link w-nav-link">Workshops</a>
+      	  </div>
+        	</div>
+      	<a href="projects.html" class="nav-link w-nav-link">Projects</a>
+      	<div class="dropdown nav-link w-nav-link">
+      	  <button class="dropbtn participants-dropdown-button">
+            Participants ▼
+      	  </button>
+      	  <div class="dropdown-content" id="participantsDropdown">
+      	    <a href="partners.html" class="nav-link w-nav-link">Partners</a>
+      		<a href="people.html" class="nav-link w-nav-link">People</a>
+      	  </div>
+        	</div>
+      	<a href="hildegard.html" class="nav-link w-nav-link">Hildegard Music Research Guide</a>
+      	<a href="mailto:debra.lacoste@dal.ca?subject=DACT%20website%20" class="w-nav-link">Contact us</a>
+    	</nav>
+    </div>
+  </div>
+	<div class="section-2">
+		<div class="div-block-3"><img src="images/alina-grubnyak-ZiQkhI7417A-unsplash.jpg" srcset="images/alina-grubnyak-ZiQkhI7417A-unsplash-p-1080.jpeg 1080w, images/alina-grubnyak-ZiQkhI7417A-unsplash-p-1600.jpeg 1600w, images/alina-grubnyak-ZiQkhI7417A-unsplash-p-2000.jpeg 2000w, images/alina-grubnyak-ZiQkhI7417A-unsplash-p-2600.jpeg 2600w, images/alina-grubnyak-ZiQkhI7417A-unsplash-p-3200.jpeg 3200w, images/alina-grubnyak-ZiQkhI7417A-unsplash.jpg 3456w" sizes="(max-width: 3456px) 100vw, 3456px" alt="" class="image-3"></div>
+		<div>
+			<div class="w-container">
+				<h3 class="heading-7">Symposia</h3>
+			</div>
+		</div>
+	</div>
+	<div class="container-6 w-container">
+		<h2>Upcoming Symposia</h2>
+		<div class="text-block-4">
+
+			<strong>December 1, 2023</strong>
+			<br>
+			(postponed from October 24, 2020)
+			<br>
+			Namur University, Belgium
+			<br>
+			Celebrating Salzinnes: A Symposium
+			<br>
+			A one-day symposium of papers and panel discussions by international scholars on topics related to the Salzinnes Antiphonal, developments in digital technology, and manuscript studies. Includes a tour through the “Centuries of Silence” exhibition at the Musée des Arts Anciens and a concert of some of the music contained in the manuscript.
+			<br>
+			<br>
+			<h4> <a href="Namur.html" target="_blank">Program and presenters.</a></h4>
+		</div>
+	</div>
+
+
+	<script src="https://d3e54v103j8qbb.cloudfront.net/js/jquery-3.4.1.min.220afd743d.js" type="text/javascript" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
+	<script src="js/webflow.js" type="text/javascript"></script>
+	<!-- [if lte IE 9]><script src="https://cdnjs.cloudflare.com/ajax/libs/placeholders/3.0.2/placeholders.min.js"></script><![endif] -->
+</body>
+</html>

--- a/symposia.html
+++ b/symposia.html
@@ -33,6 +33,7 @@
       	    <a href="presentations.html" class="nav-link w-nav-link">Presentations</a>
       		<a href="publications.html" class="nav-link w-nav-link">Publications</a>
       		<a href="workshops.html" class="nav-link w-nav-link">Workshops</a>
+      		<a href="symposia.html" class="nav-link w-nav-link">Symposia</a>
       	  </div>
         	</div>
       	<a href="projects.html" class="nav-link w-nav-link">Projects</a>

--- a/symposia.html
+++ b/symposia.html
@@ -75,6 +75,14 @@
 			<br>
 			<h4> <a href="Namur.html" target="_blank">Program and presenters.</a></h4>
 		</div>
+		<div class="text-block-4">
+			<strong>Latin Chant Notations - Study Day (online)</strong>
+			<br>
+			March 22, 2024
+			<br>
+			Hosted by the DACT Notation Team
+			<br>
+		</div>
 	</div>
 
 

--- a/symposia.html
+++ b/symposia.html
@@ -73,12 +73,12 @@
 			A one-day symposium of papers and panel discussions by international scholars on topics related to the Salzinnes Antiphonal, developments in digital technology, and manuscript studies. Includes a tour through the “Centuries of Silence” exhibition at the Musée des Arts Anciens and a concert of some of the music contained in the manuscript.
 			<br>
 			<br>
-			<h4> <a href="Namur.html" target="_blank">Program and presenters.</a></h4>
+			<h4><a href="Namur.html" target="_blank">Program and presenters.</a></h4>
 		</div>
 		<div class="text-block-4">
-			<strong>Latin Chant Notations - Study Day (online)</strong>
-			<br>
-			March 22, 2024
+            <strong>March 22, 2024</strong>
+            <br>
+			Latin Chant Notations - Study Day (online)
 			<br>
 			Hosted by the DACT Notation Team
 			<br>

--- a/workshops.html
+++ b/workshops.html
@@ -60,19 +60,6 @@
 		</div>
 	</div>
 	<div class="container-6 w-container">
-		<h2>Upcoming Workshops</h2>
-		<div class="text-block-4">
-			<strong>Check for updates!</strong>
-			<br>
-			<br>
-			<strong>Latin Chant Notations - Study Day (online):</strong>
-			<br>
-			March 22, 2024
-			<br>
-			Hosted by the DACT Notation Team
-			<br>
-		</div>
-		<hr>
 		<h2 id="2023">2023</h2>
 		<div class="text-block-4">
 			<strong>Workshop 15, DACT Project Update (in-person):</strong>

--- a/workshops.html
+++ b/workshops.html
@@ -61,7 +61,7 @@
 		</div>
 	</div>
 	<div class="container-6 w-container">
-		<h2 id="2023">2023</h2>
+		<h3 id="2023">2023</h3>
 		<div class="text-block-4">
 			<strong>Workshop 15, DACT Project Update (in-person):</strong>
 			<br>
@@ -107,7 +107,7 @@
 			In attendance on Zoom (38): Maria Alexandru, Alison Altstatt, Jennifer Bain, Inga Behrendt, Virginia Blanton, Susan Boynton, Catherine Bradley, Christelle Cazaux, Katharine Chandler, Anna de Bakker, Elsa De Luca, Lucia Denk, Ichiro Fujinaga, Eszter Gaál, Gabriella Gilányi, Richard Haefer, Barbara Haggh-Huglo, Andrew Hankinson, Kate Helsen, Elaine Hild, Alessandra Ignesti, Arsinoi Ioannidou, Debra Lacoste, Rachel McNellis, Stefan Morent, Julianna Nagy Torma, Tiago Alexandre Pinto, Laurent Pugin, Rebecca Shaw, Nikolaos Siklafidis, Sara Simenyi, Martha Thomae Elias, Inês Trinidade, Janice Tulk, Haig Utidjian, Eva Veselovská, Hilkka-Liisa Vuori, David Watt.				
 		</div>
 		<hr>
-		<h2 id="2022">2022</h2>
+		<h3 id="2022">2022</h3>
 		<div class="text-block-4">
 			<strong>Workshop 11, Dynamic Chant Bibliographies (online):</strong>	
 			<br>
@@ -181,7 +181,7 @@
 			<br>
 		</div>
 		<hr>
-		<h2 id="2021">2021</h2>
+		<h3 id="2021">2021</h3>
 		<div class="text-block-4">
 			<strong>Workshop 5, Fragments (online): </strong>
 			<br>
@@ -207,7 +207,7 @@
 			<br>
 		</div>
 		<hr>
-		<h2 id="2020">2020</h2>
+		<h3 id="2020">2020</h3>
 		<div class="text-block-4">
 			<strong>Workshop 3, Project Update (moved online):</strong>
 			<br>
@@ -229,7 +229,7 @@
 			<br>
 		</div>
 		<hr>
-		<h2 id="2019">2019</h2>
+		<h3 id="2019">2019</h3>
 		<div class="text-block-4">
 			<strong>Workshop 1, Project Introduction: </strong>
 			<br>

--- a/workshops.html
+++ b/workshops.html
@@ -34,6 +34,7 @@
       	    <a href="presentations.html" class="nav-link w-nav-link">Presentations</a>
       		<a href="publications.html" class="nav-link w-nav-link">Publications</a>
       		<a href="workshops.html" class="nav-link w-nav-link">Workshops</a>
+      		<a href="symposia.html" class="nav-link w-nav-link">Symposia</a>
       	  </div>
         	</div>
       	<a href="projects.html" class="nav-link w-nav-link">Projects</a>


### PR DESCRIPTION
This PR
- creates a new page, `symposia.html`
- moves content from `workshops.html` and `presentations.html` to `symposia.html`
- adds a link to the navbar of each page to `symposia.html`, nested within "Activities"
- standardizes formatting on `presentations.html`, `publications.html`, and `workshops.html`
  - These pages were organized by year - some pages had the year in `<h2>` tags, while others had the year in `<h4>` tags
  - All these pages now use `<h3>` tags.
  - When it becomes necessary to add "Upcoming Presentations"/"Past Presentations" sections, these can be added at the `<h2>` level, and the existing content will nest nicely within those sections.

This is how the new Symposia page looks:
![Screen Shot 2023-11-16 at 15 27 22](https://github.com/dact-chant/dact-chant.github.io/assets/58090591/3901b917-5afd-4f7b-854d-ff2f821c94a9)

This is how `presentations.html` looks with the new header levels (`publications.html` and `workshops.html` are formatted similarly):
![Screen Shot 2023-11-16 at 15 29 01](https://github.com/dact-chant/dact-chant.github.io/assets/58090591/6ff008e8-0fa0-4404-b2dc-9accac35331f)

For comparison, this is how `presentations.html` looked before these changes:
![Screen Shot 2023-11-16 at 15 30 33](https://github.com/dact-chant/dact-chant.github.io/assets/58090591/5929ad35-aac3-44b4-be6e-c7d59dd9fe4f)
