### PR TITLE
switch back to old SSHRC logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
       		<a href="publications.html" class="nav-link w-nav-link">Publications</a>
       		<a href="workshops.html" class="nav-link w-nav-link">Workshops</a>
       		<a href="symposia.html" class="nav-link w-nav-link">Symposia</a>
-			<a href="exhibitions.html" class="nav-link w-nav-link">Exhibitions</a> 
+			<a href="exhibitions.html" class="nav-link w-nav-link">Exhibitions</a>
       	  </div>
         	</div>
       	<a href="projects.html" class="nav-link w-nav-link">Projects</a>
@@ -68,8 +68,7 @@
             <button class="button" type="button"> <a href="https://docs.google.com/forms/d/e/1FAIpQLSd9EC1fROEoRjsws0_BhhgoaM2xWyf-d1w1EoAIx9gSScFE6g/viewform?usp=sf_link" target="_blank"><strong>Submit a Fragment</strong></a></button><br>
           <br>DACT has been awarded a 7-year SSHRC Partnership grant (2023-2030, SSHRC: 895-2023-1002). Previous funding included a 3-year SSHRC Partnership Development grant in the 2018 competition (2019-2022+, SSHRC: 890-2018-0024) and the Stage 1 Partnership grant (2022, SSHRC: 895-2022-0011); work on this project is ongoing. This website provides a brief overview of the project and its participants. For more information, please contact Jennifer Bain (<a href="mailto:jennifer.bain@dal.ca?subject=DACT%20inquiry%20from%20website">jennifer.bain@dal.ca</a>) or Debra Lacoste (<a href="mailto:debra.lacoste@dal.ca?subject=DACT%20inquiry%20from%20website">debra.lacoste@dal.ca</a>).
         </div>
-	<a href="https://www.sshrc-crsh.gc.ca/results-resultats/recipients-recipiendaires/2022/pg-sp-eng.aspx" target="_blank"><img src="images/SSHRC-logo-no border.png" width="500" srcset="images/SSRCH-logo-no border.png 500w, images/SSRCH-logo-no border.png 800w, images/SSRCH-logo-no border.png 1080w, images/SSRCH-logo-no border.png 1507w" sizes="(max-width: 767px) 96vw, (max-width: 991px) 541px, 636px" style="padding: 3px" alt="SSHRC logo" class="image-4"></a>
-	<img src="images/Canada.png" width="175" alt="Canada" class="image-4">
+	<a href="https://www.sshrc-crsh.gc.ca/results-resultats/recipients-recipiendaires/2022/pg-sp-eng.aspx" target="_blank"><img src="images/SSHRC-CRSH_FIP.jpg" width="500" srcset="images/SSHRC-CRSH_FIP.jpg 500w, images/SSHRC-CRSH_FIP.jpg 800w, images/SSHRC-CRSH_FIP.jpg 1080w, images/SSHRC-CRSH_FIP.jpg 1507w" sizes="(max-width: 767px) 96vw, (max-width: 991px) 541px, 636px" style="padding: 3px; display: block; margin: auto;" alt="SSHRC logo" class="image-4"></a>
         <a href="https://www.dal.ca/faculty/arts/school-of-performing-arts.html" target="_blank"><img src="images/01%20DAL%20FullMark-Blk.jpg" width="300" srcset="images/01%20DAL%20FullMark-Blk.jpg 500w, images/01%20DAL%20FullMark-Blk.jpg 800w, images/01%20DAL%20FullMark-Blk.jpg 1080w, images/01%20DAL%20FullMark-Blk.jpg 1507w" sizes="(max-width: 767px) 96vw, (max-width: 991px) 541px, 636px" style="padding: 3px" alt="Dalhousie University logo" class="image-4"></a>
         <a href="https://alliancecan.ca/en" target="_blank"><img src="images/DigitalAlliance.png" width="375" srcset="images/DigitalAlliance.png 500w, images/DigitalAlliance.png 800w, images/DigitalAlliance.png 1080w, images/DigitalAlliance.png 1507w" sizes="(max-width: 767px) 96vw, (max-width: 991px) 541px, 636px" style="padding: 3px" alt="Digital Research Alliance logo" class="image-4"></a></div>
       <div class="column w-col w-col-3">
@@ -78,7 +77,7 @@
 	  <li><a href="https://situate.io/dact/" target="_blank">DACT App</a></li>
 	  <li><a href="https://dact-chant.ca/files/What-is-DACT.pdf" target="_blank">What is DACT?</a></li>
           <li><a href="https://cantusdatabase.org/" target="_blank">Cantus: A Database for Latin Ecclesiastical Chant</a></li>
-          <li><a href="http://cantusindex.org/" target="_blank">Cantus Index</a></li>		
+          <li><a href="http://cantusindex.org/" target="_blank">Cantus Index</a></li>
           <li><a href="Namur.html" target="_blank">Celebrating Salzinnes: A Symposium</a></li>
           <li><a href="https://twitter.com/DactF" target="_blank">DACT Fragments X (Twitter)</a></li>
           <li><a href="https://cantus.simssa.ca/" target="_blank">Cantus Ultimus</a></li>


### PR DESCRIPTION
This changes the logo back to the original SSHRC logo with the Canadian flag. Addresses issue #6.